### PR TITLE
Possible sollution for CC-16 (constructor injection)

### DIFF
--- a/constretto-api/src/main/java/org/constretto/annotation/Configure.java
+++ b/constretto-api/src/main/java/org/constretto/annotation/Configure.java
@@ -23,7 +23,7 @@ import java.lang.annotation.*;
  *  
  * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
  */
-@Target({ElementType.METHOD})
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface Configure {

--- a/constretto-core/src/main/java/org/constretto/internal/DefaultConstrettoConfiguration.java
+++ b/constretto-core/src/main/java/org/constretto/internal/DefaultConstrettoConfiguration.java
@@ -32,9 +32,7 @@ import org.constretto.model.ConfigurationValue;
 
 import java.lang.annotation.Annotation;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -129,13 +127,46 @@ public class DefaultConstrettoConfiguration implements ConstrettoConfiguration {
     public <T> T as(Class<T> configurationClass) throws ConstrettoException {
         T objectToConfigure;
         try {
-            objectToConfigure = configurationClass.newInstance();
+            objectToConfigure = createInstance(configurationClass);
         } catch (Exception e) {
             throw new ConstrettoException("Could not instansiate class of type: " + configurationClass.getName()
                     + " when trying to inject it with configuration, It may be missing a default constructor", e);
         }
         injectConfiguration(objectToConfigure);
         return objectToConfigure;
+    }
+
+    private <T> T createInstance(final Class<T> configurationClass) throws InstantiationException, IllegalAccessException {
+
+
+        if (configurationClass.isMemberClass() || configurationClass.isAnonymousClass()) {
+            throw new ConstrettoException("Can not instantiate inner or anonymous classes using. To inject configuration in to inner or anonymous classes, " +
+                                                  "instantiate it first ant call the on(T configuredObjecT) method");
+        }
+        Constructor<T> annotatedConstructor = findFirstAnnotatedConstructor(configurationClass);
+        if(annotatedConstructor == null) {
+            return configurationClass.newInstance();
+        } else {
+            final Object[] resolvedParameters = resolveParameters(annotatedConstructor);
+            try {
+                annotatedConstructor.setAccessible(true);
+                return annotatedConstructor.newInstance(resolvedParameters);
+            } catch (InvocationTargetException e) {
+                throw new ConstrettoException("Could not instantiate class with @Configure annotated constructor");
+            }
+
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Constructor<T> findFirstAnnotatedConstructor(final Class<T> configurationClass) {
+        Constructor<?>[] constructors = configurationClass.getConstructors();
+        for(Constructor<?> constructor: constructors) {
+            if(constructor.isAnnotationPresent(Configure.class)) {
+                return (Constructor<T>) constructor;
+            }
+        }
+        return null;
     }
 
     public <T> T on(T objectToConfigure) throws ConstrettoException {
@@ -277,70 +308,109 @@ public class DefaultConstrettoConfiguration implements ConstrettoConfiguration {
         }
     }
 
+    
+    
+    private Object[] resolveParameters(AccessibleObject accessibleObject) throws IllegalAccessException, InstantiationException {
+        Annotation[][] methodAnnotations;
+        String[] parameterNames;
+        Class<?>[] parameterTargetTypes;
+
+        if(accessibleObject instanceof Method) {
+            Method method = (Method) accessibleObject;
+            methodAnnotations = method.getParameterAnnotations();
+            parameterNames = paranamer.lookupParameterNames(method);
+            parameterTargetTypes = method.getParameterTypes();
+        } else if(accessibleObject instanceof Constructor) {
+            Constructor constructor = (Constructor) accessibleObject;
+            methodAnnotations = constructor.getParameterAnnotations();
+            parameterNames = paranamer.lookupParameterNames(constructor);
+            parameterTargetTypes = constructor.getParameterTypes();
+        } else {
+            throw new ConstrettoException("Could not resolve parameter names ");
+        }
+
+        Object[] resolvedArguments = new Object[methodAnnotations.length];
+        int i = 0;
+        for (Annotation[] parameterAnnotations : methodAnnotations) {
+            Object defaultValue = null;
+            boolean required = true;
+            String expression = "";
+            Class<?> parameterTargetClass = parameterTargetTypes[i];
+            if (parameterAnnotations.length != 0) {
+                for (Annotation parameterAnnotation : parameterAnnotations) {
+                    if (parameterAnnotation.annotationType() == Configuration.class) {
+                        Configuration configurationAnnotation = (Configuration) parameterAnnotation;
+                        expression = configurationAnnotation.value();
+                        required = configurationAnnotation.required();
+                        if (hasAnnotationDefaults(configurationAnnotation)) {
+                            if (configurationAnnotation.defaultValueFactory().equals(Configuration.EmptyValueFactory.class)) {
+                                defaultValue = ValueConverterRegistry.convert(parameterTargetClass, parameterTargetClass, new CPrimitive(configurationAnnotation.defaultValue()));
+                            } else {
+                                ConfigurationDefaultValueFactory valueFactory = configurationAnnotation.defaultValueFactory().newInstance();
+                                defaultValue = valueFactory.getDefaultValue();
+                            }
+                        }
+                    }
+                }
+            }
+            if (expression.equals("")) {
+                if (parameterNames == null) {
+                    throw new ConstrettoException("Could not resolve the expression of the property to look up. " +
+                            "The cause of this could be that the class is compiled without debug enabled. " +
+                            "when a class is compiled without debug, the @Configuration with a value attribute is required " +
+                            "to correctly resolve the property expression.");
+                } else {
+                    expression = parameterNames[i];
+                }
+            }
+            if (hasValue(expression)) {
+                if (parameterTargetClass.isAssignableFrom(List.class)) {
+                    Class<?> collectionParameterType = getCollectionParameterType(createMethodParameter(accessibleObject, i));
+                    resolvedArguments[i] = evaluateToList(collectionParameterType, expression);
+                } else if (parameterTargetClass.isAssignableFrom(Map.class)) {
+                    Class<?> mapKeyType = getMapKeyParameterType(createMethodParameter(accessibleObject, i));
+                    Class<?> mapValueType = getMapValueParameterType(createMethodParameter(accessibleObject, i));
+                    resolvedArguments[i] = evaluateToMap(mapKeyType, mapValueType, expression);
+                } else {
+                    resolvedArguments[i] = processAndConvert(parameterTargetClass, expression);
+                }
+
+            } else {
+                if (defaultValue != null || !required) {
+                    resolvedArguments[i] = defaultValue;
+                } else {
+                    if(accessibleObject instanceof Constructor) {
+                        Constructor constructor = (Constructor) accessibleObject;
+                        throw new ConstrettoException("Missing value or default value for expression [" + expression + "], in annotated constructor in class [" + constructor.getClass().getName() + "], with tags " + currentTags + ".");
+
+                    }
+                   else {
+                       Method method = (Method) accessibleObject;
+                        throw new ConstrettoException("Missing value or default value for expression [" + expression + "], in method [" + method.getName() + "], in class [" + method.getClass().getName() + "], with tags " + currentTags + ".");
+
+                   }
+                }
+            }
+
+            i++;
+        }
+        return resolvedArguments;
+        
+    }
+    
+    private <T extends AccessibleObject> MethodParameter createMethodParameter(T accessibleObject, final int parameterIndex) {
+        if(accessibleObject instanceof Constructor) {
+            return new MethodParameter((Constructor) accessibleObject, parameterIndex);
+        } else {
+            return new MethodParameter((Method) accessibleObject, parameterIndex);
+        }
+    }
     private <T> void injectMethods(T objectToConfigure) {
         Method[] methods = objectToConfigure.getClass().getMethods();
         for (Method method : methods) {
             try {
                 if (method.isAnnotationPresent(Configure.class)) {
-                    Annotation[][] methodAnnotations = method.getParameterAnnotations();
-                    String[] parameterNames = paranamer.lookupParameterNames(method);
-                    Object[] resolvedArguments = new Object[methodAnnotations.length];
-                    int i = 0;
-                    for (Annotation[] parameterAnnotations : methodAnnotations) {
-                        Object defaultValue = null;
-                        boolean required = true;
-                        String expression = "";
-                        Class<?> parameterTargetClass = method.getParameterTypes()[i];
-                        if (parameterAnnotations.length != 0) {
-                            for (Annotation parameterAnnotation : parameterAnnotations) {
-                                if (parameterAnnotation.annotationType() == Configuration.class) {
-                                    Configuration configurationAnnotation = (Configuration) parameterAnnotation;
-                                    expression = configurationAnnotation.value();
-                                    required = configurationAnnotation.required();
-                                    if (hasAnnotationDefaults(configurationAnnotation)) {
-                                        if (configurationAnnotation.defaultValueFactory().equals(Configuration.EmptyValueFactory.class)) {
-                                            defaultValue = ValueConverterRegistry.convert(parameterTargetClass, parameterTargetClass, new CPrimitive(configurationAnnotation.defaultValue()));
-                                        } else {
-                                            ConfigurationDefaultValueFactory valueFactory = configurationAnnotation.defaultValueFactory().newInstance();
-                                            defaultValue = valueFactory.getDefaultValue();
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        if (expression.equals("")) {
-                            if (parameterNames == null) {
-                                throw new ConstrettoException("Could not resolve the expression of the property to look up. " +
-                                        "The cause of this could be that the class is compiled without debug enabled. " +
-                                        "when a class is compiled without debug, the @Configuration with a value attribute is required " +
-                                        "to correctly resolve the property expression.");
-                            } else {
-                                expression = parameterNames[i];
-                            }
-                        }
-                        if (hasValue(expression)) {
-                            if (parameterTargetClass.isAssignableFrom(List.class)) {
-                                Class<?> collectionParameterType = getCollectionParameterType(new MethodParameter(method, i));
-                                resolvedArguments[i] = evaluateToList(collectionParameterType, expression);
-                            } else if (parameterTargetClass.isAssignableFrom(Map.class)) {
-                                Class<?> mapKeyType = getMapKeyParameterType(new MethodParameter(method, i));
-                                Class<?> mapValueType = getMapValueParameterType(new MethodParameter(method, i));
-                                resolvedArguments[i] = evaluateToMap(mapKeyType, mapValueType, expression);
-                            } else {
-                                resolvedArguments[i] = processAndConvert(parameterTargetClass, expression);
-                            }
-
-                        } else {
-                            if (defaultValue != null || !required) {
-                                resolvedArguments[i] = defaultValue;
-                            } else {
-                                throw new ConstrettoException("Missing value or default value for expression [" + expression + "], in method [" + method.getName() + "], in class [" + objectToConfigure.getClass().getName() + "], with tags " + currentTags + ".");
-                            }
-                        }
-
-                        i++;
-                    }
-
+                    Object[] resolvedArguments = resolveParameters(method);
                     method.setAccessible(true);
                     method.invoke(objectToConfigure, resolvedArguments);
 

--- a/constretto-core/src/main/java/org/constretto/internal/MethodParameter.java
+++ b/constretto-core/src/main/java/org/constretto/internal/MethodParameter.java
@@ -86,6 +86,34 @@ public class MethodParameter {
     }
 
     /**
+     * Create a new MethodParameter for the given constructor, with nesting level 1.
+     *
+     * @param constructor    the Constructor to specify a parameter for
+     * @param parameterIndex the index of the parameter
+     */
+    public MethodParameter(Constructor constructor, int parameterIndex) {
+        this(constructor, parameterIndex, 1);
+    }
+
+    /**
+     * Create a new MethodParameter for the given constructor.
+     *
+     * @param constructor    the Constructor to specify a parameter for
+     * @param parameterIndex the index of the parameter
+     * @param nestingLevel   the nesting level of the target type
+     *                       (typically 1; e.g. in case of a List of Lists, 1 would indicate the
+     *                       nested List, whereas 2 would indicate the element of the nested List)
+     */
+    public MethodParameter(Constructor constructor, int parameterIndex, int nestingLevel) {
+        if (constructor == null) {
+            throw new NullPointerException("Constructor must not be null");
+        }
+        this.constructor = constructor;
+        this.parameterIndex = parameterIndex;
+        this.nestingLevel = nestingLevel;
+    }
+
+    /**
      * Return the wrapped Method, if any.
      * <p>Note: Either Method or Constructor is available.
      *

--- a/constretto-core/src/test/java/org/constretto/internal/ConstructorAnnotationClassTest.java
+++ b/constretto-core/src/test/java/org/constretto/internal/ConstructorAnnotationClassTest.java
@@ -1,0 +1,68 @@
+package org.constretto.internal;
+
+import org.constretto.ConstrettoBuilder;
+import org.constretto.ConstrettoConfiguration;
+import org.constretto.annotation.Configure;
+import org.constretto.exception.ConstrettoException;
+import org.constretto.model.Resource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *  @author <a href=mailto:zapodot.com>Sondre Eikanger Kval&oslash;</a>
+ */
+public class ConstructorAnnotationClassTest {
+
+    ConstrettoConfiguration config;
+
+    @Before
+    public void before() {
+        config = new ConstrettoBuilder()
+                .createPropertiesStore()
+                .addResource(new Resource("classpath:subClassData.properties"))
+                .done()
+                .getConfiguration();
+    }
+
+
+    @Test
+    public void testIncjectOnConstructor() throws Exception {
+        NonLocalConfigurationClass nonLocalConfigurationClassObject = config.as(NonLocalConfigurationClass.class);
+        assertEquals("value", nonLocalConfigurationClassObject.getValue());
+
+    }
+
+
+    /**
+     * Because we can not inject parameter values to @Configure annotated constructors in inner classes,
+     * we expect a ConstrettoException
+     *
+     * @throws Exception
+     */
+    @Test(expected = ConstrettoException.class)
+    public void testInjectOnConstructorInnerClass() throws Exception {
+        config.as(InnerClassWithNoDefaultConstructor.class);
+    }
+
+    private class InnerClassWithNoDefaultConstructor {
+
+        private String property;
+
+        @Configure
+        public InnerClassWithNoDefaultConstructor(final String value) {
+            this.property = value;
+        }
+
+        public String getProperty() {
+            return property;
+        }
+    }
+
+
+}

--- a/constretto-core/src/test/java/org/constretto/internal/NonLocalConfigurationClass.java
+++ b/constretto-core/src/test/java/org/constretto/internal/NonLocalConfigurationClass.java
@@ -1,0 +1,22 @@
+package org.constretto.internal;
+
+import org.constretto.annotation.Configure;
+
+/**
+ * Used to test @Configure annotated constructors.
+ *
+ * @author <a href=mailto:zapodot.com>Sondre Eikanger Kval&oslash;</a>
+ */
+public class NonLocalConfigurationClass {
+
+    private String value;
+
+    @Configure
+    public NonLocalConfigurationClass(final String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
- @configure annotated constructors must be public
- Inner classes are not supported as this requires Constretto to know the outer class instance. Trying to inject configuration on an inner class will throw a Constretto Exception.

Could posible be postphoned to future releases (e.g Constretto 2.1) as it does some fundamental classes (including the @Configure annotation). However the old Method injection logic is now used both for constructors and method and should be fairly stable
