### PR TITLE
Add support of command param CONSTRETTO_OVERRIDE...

### DIFF
--- a/constretto-core/src/main/java/org/constretto/ConstrettoBuilder.java
+++ b/constretto-core/src/main/java/org/constretto/ConstrettoBuilder.java
@@ -30,6 +30,7 @@ import java.util.*;
  */
 public class ConstrettoBuilder {
 
+    public static final String OVERRIDES = "CONSTRETTO_OVERRIDES";
     private final List<ConfigurationStore> configurationStores;
     private final List<String> tags;
     private final boolean enableSystemProps;
@@ -63,6 +64,8 @@ public class ConstrettoBuilder {
 
 
     public ConstrettoConfiguration getConfiguration() {
+        addOverrideStores();
+
         Map<String, List<ConfigurationValue>> configuration = new HashMap<String, List<ConfigurationValue>>();
         Collection<TaggedPropertySet> taggedPropertySets = loadPropertySets();
         for (TaggedPropertySet taggedPropertySet : taggedPropertySets) {
@@ -84,6 +87,30 @@ public class ConstrettoBuilder {
             }
         }
         return new DefaultConstrettoConfiguration(configuration, tags);
+    }
+
+    private void addOverrideStores() {
+        String overrideValue = System.getProperty(OVERRIDES);
+
+        if (overrideValue != null) {
+            String[] locations = overrideValue.split(",");
+
+            for (String location : locations) {
+                addOverrideStore(location);
+            }
+        }
+    }
+
+    private void addOverrideStore(String location) {
+        if (location.endsWith(".properties")) {
+            PropertiesStoreBuilder propertiesBuilder = createPropertiesStore();
+            propertiesBuilder.addResource(Resource.create(location));
+            propertiesBuilder.done();
+        } else if (location.endsWith(".ini")) {
+            IniFileConfigurationStoreBuilder iniBuilder = createIniFileConfigurationStore();
+            iniBuilder.addResource(Resource.create(location));
+            iniBuilder.done();
+        }
     }
 
     public ConstrettoBuilder addCurrentTag(String tag) {

--- a/constretto-core/src/test/java/org/constretto/ConstrettoConfigurationTest.java
+++ b/constretto-core/src/test/java/org/constretto/ConstrettoConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.constretto;
 
 import org.constretto.model.ClassPathResource;
+import org.constretto.model.Resource;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -68,4 +69,65 @@ public class ConstrettoConfigurationTest {
         assertEquals(2,props.size());
     }
 
+    @Test
+    public void getConfiguration_iniStoreWithoutOverride() {
+        ConstrettoConfiguration configuration = new ConstrettoBuilder()
+                .createIniFileConfigurationStore().addResource(Resource.create("classpath:cache1.ini")).done()
+                .getConfiguration();
+
+        assertEquals(configuration.evaluateToString("key1"), "value1");
+    }
+
+    @Test
+    public void getConfiguration_iniStoreWithOneOverride() {
+        System.setProperty(ConstrettoBuilder.OVERRIDES, "classpath:cache1-override1.ini");
+        ConstrettoConfiguration configuration = new ConstrettoBuilder()
+                .createIniFileConfigurationStore().addResource(Resource.create("classpath:cache1.ini")).done()
+                .getConfiguration();
+
+        assertEquals(configuration.evaluateToString("key1"), "value1-override1");
+        System.clearProperty(ConstrettoBuilder.OVERRIDES);
+    }
+
+    @Test
+    public void getConfiguration_iniStoreWithTwoOverrides() {
+        System.setProperty(ConstrettoBuilder.OVERRIDES, "classpath:cache1-override1.ini,classpath:cache1-override2.ini");
+        ConstrettoConfiguration configuration = new ConstrettoBuilder()
+                .createIniFileConfigurationStore().addResource(Resource.create("classpath:cache1.ini")).done()
+                .getConfiguration();
+
+        assertEquals(configuration.evaluateToString("key1"), "value1-override2");
+        System.clearProperty(ConstrettoBuilder.OVERRIDES);
+    }
+
+    @Test
+    public void getConfiguration_propertyStoreWithoutOverride() {
+        ConstrettoConfiguration configuration = new ConstrettoBuilder()
+                .createPropertiesStore().addResource(Resource.create("classpath:cache3.properties")).done()
+                .getConfiguration();
+
+        assertEquals(configuration.evaluateToString("key3"), "value3");
+    }
+
+    @Test
+    public void getConfiguration_propertyStoreWithOneOverride() {
+        System.setProperty(ConstrettoBuilder.OVERRIDES, "classpath:cache3-override1.properties");
+        ConstrettoConfiguration configuration = new ConstrettoBuilder()
+                .createPropertiesStore().addResource(Resource.create("classpath:cache3.properties")).done()
+                .getConfiguration();
+
+        assertEquals(configuration.evaluateToString("key3"), "value3-override1");
+        System.clearProperty(ConstrettoBuilder.OVERRIDES);
+    }
+
+    @Test
+    public void getConfiguration_propertyStoreWithTwoOverrides() {
+        System.setProperty(ConstrettoBuilder.OVERRIDES, "classpath:cache3-override1.properties,classpath:cache3-override2.properties");
+        ConstrettoConfiguration configuration = new ConstrettoBuilder()
+                .createPropertiesStore().addResource(Resource.create("classpath:cache3.properties")).done()
+                .getConfiguration();
+
+        assertEquals(configuration.evaluateToString("key3"), "value3-override2");
+        System.clearProperty(ConstrettoBuilder.OVERRIDES);
+    }
 }

--- a/constretto-core/src/test/resources/cache1-override1.ini
+++ b/constretto-core/src/test/resources/cache1-override1.ini
@@ -1,0 +1,18 @@
+#
+# Copyright 2011 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[default]
+key1=value1-override1

--- a/constretto-core/src/test/resources/cache1-override2.ini
+++ b/constretto-core/src/test/resources/cache1-override2.ini
@@ -1,0 +1,18 @@
+#
+# Copyright 2011 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[default]
+key1=value1-override2

--- a/constretto-core/src/test/resources/cache3-override1.properties
+++ b/constretto-core/src/test/resources/cache3-override1.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2011 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+key3=value3-override1

--- a/constretto-core/src/test/resources/cache3-override2.properties
+++ b/constretto-core/src/test/resources/cache3-override2.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2011 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+key3=value3-override2


### PR DESCRIPTION
...to easily support override of properties runtime.

Hi, Kaare!

We've been talking a couple of times how Constretto could handle an override file given runtime. I have worked with Tor Arne Kvaløy today with a patch that makes this possible. We tried different solutions, but ended up using a new cmd parameter that can take one or more stores to add to the builder. 

When doing this, both Spring XML and Java is supported out of the box. Our applications don't need any changes getting the new feature working, and there should be no side effects either. 

We were wondering if the code for reading the override param should be placed in "DefaultConfigurationContextResolver". Do you have any thoughts of that?

And what do you think about this feature?

Thanks!

Best regards
Endre M. Meckelborg
FINN oppdrag
