### PR TITLE
Fixed CPrimitive.replace so it quotes replacementValue

### DIFF
--- a/constretto-api/pom.xml
+++ b/constretto-api/pom.xml
@@ -16,4 +16,11 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>constretto-api</artifactId>
   <name>Constretto :: API - ${project.version}</name>
+
+  <dependencies>
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/constretto-api/src/main/java/org/constretto/model/CPrimitive.java
+++ b/constretto-api/src/main/java/org/constretto/model/CPrimitive.java
@@ -33,7 +33,7 @@ public class CPrimitive extends CValue {
 
     @Override
     public void replace(String key, String resolvedValue) {
-        value = value.replaceAll("#\\{" + key + "\\}", resolvedValue);
+        value = value.replaceAll("#\\{" + key + "\\}", Matcher.quoteReplacement(resolvedValue));
     }
 
     @Override

--- a/constretto-api/src/test/java/org/constretto/model/CPrimitiveTest.java
+++ b/constretto-api/src/test/java/org/constretto/model/CPrimitiveTest.java
@@ -1,0 +1,18 @@
+package org.constretto.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public final class CPrimitiveTest {
+    @Test
+    public void replace() throws Exception {
+        final String key = "my-key";
+        final CPrimitive primitive = new CPrimitive("#{" + key + "}");
+        final String expectedValue = "C:\\temp\\";
+
+        primitive.replace(key, expectedValue);
+
+        assertEquals(expectedValue, primitive.value());
+    }
+}


### PR DESCRIPTION
Hi,

Using constretto on windows, revealed a bug in CPrimitive.replace. I've included a testcase that reproduces this. As well as a fix.
Could you please merge this patch?

Thanks!
