### PR TITLE
Improving parameterization nesting handling

### DIFF
--- a/constretto-core/src/main/java/org/constretto/internal/GenericCollectionTypeResolver.java
+++ b/constretto-core/src/main/java/org/constretto/internal/GenericCollectionTypeResolver.java
@@ -39,7 +39,7 @@ public abstract class GenericCollectionTypeResolver {
      * @return the generic type, or <code>null</code> if none
      */
     public static Class<?> getCollectionFieldType(Field collectionField) {
-        return getGenericFieldType(collectionField, Collection.class, 0, 1);
+        return getGenericFieldType(collectionField, Collection.class, 0, getNestingLevel(collectionField.getGenericType(), 0));
     }
 
     /**
@@ -49,7 +49,7 @@ public abstract class GenericCollectionTypeResolver {
      * @return the generic type, or <code>null</code> if none
      */
     public static Class<?> getMapKeyFieldType(Field mapField) {
-        return getGenericFieldType(mapField, Map.class, 0, 1);
+        return getGenericFieldType(mapField, Map.class, 0, getNestingLevel(mapField.getGenericType(), 0));
     }
 
     /**
@@ -59,7 +59,7 @@ public abstract class GenericCollectionTypeResolver {
      * @return the generic type, or <code>null</code> if none
      */
     public static Class<?> getMapValueFieldType(Field mapField) {
-        return getGenericFieldType(mapField, Map.class, 1, 1);
+        return getGenericFieldType(mapField, Map.class, 1, getNestingLevel(mapField.getGenericType(), 0));
     }
 
     /**
@@ -122,6 +122,24 @@ public abstract class GenericCollectionTypeResolver {
     }
 
     /**
+     * Recursively find the nesting level of a generic type.
+     *
+     * @param type 			the
+     * @param nestingLevel 	calculated nesting level. Initial call using 0
+     * @return
+     */
+    static int getNestingLevel(final Type type, final int nestingLevel){
+        if(type instanceof ParameterizedType){
+            final Type[] paramTypes = ((ParameterizedType) type).getActualTypeArguments();
+            return getNestingLevel(paramTypes[paramTypes.length-1], nestingLevel +1);
+        } else {
+            return nestingLevel;
+        }
+
+    }
+
+
+    /**
      * Extract the generic type from the given Type object.
      *
      * @param methodParam  the method parameter specification
@@ -177,7 +195,7 @@ public abstract class GenericCollectionTypeResolver {
             // Default is last parameter type: Collection element or Map value.
             int indexToUse = (currentTypeIndex != null ? currentTypeIndex : paramTypes.length - 1);
             Type paramType = paramTypes[indexToUse];
-            return extractType(methodParam, paramType, source, typeIndex, nestingLevel, nextLevel);
+            return extractType(methodParam, paramType, null, typeIndex, nestingLevel, nextLevel);
         }
         if (source != null && !source.isAssignableFrom(rawType)) {
             return null;

--- a/constretto-core/src/test/java/org/constretto/internal/converter/ValueConverterRegistryTest.java
+++ b/constretto-core/src/test/java/org/constretto/internal/converter/ValueConverterRegistryTest.java
@@ -15,6 +15,12 @@
  */
 package org.constretto.internal.converter;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.constretto.exception.ConstrettoException;
 import org.constretto.model.CArray;
 import org.constretto.model.CObject;
@@ -22,8 +28,6 @@ import org.constretto.model.CPrimitive;
 import org.constretto.model.CValue;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.*;
 
 /**
  * @author <a href="mailto:asbjorn@aarrestad.com">Asbj&oslash;rn Aarrestad</a>
@@ -41,6 +45,17 @@ public class ValueConverterRegistryTest {
 		Assert.assertTrue(convertedList.size() == 1);
 	}
 
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void simpleMapConversion() {
+		final Map<String, CValue> map = new HashMap<String, CValue>();
+		map.put("hei", new CPrimitive("hallo"));
+		final Map<String,String> convertedMap = (Map<String,String>) ValueConverterRegistry.convert(String.class, String.class, new CObject(map));
+
+		Assert.assertNotNull(convertedMap);
+		Assert.assertTrue(convertedMap.size() == 1);
+	}
 
     @Test
 	public void mapListConversion() {
@@ -77,6 +92,8 @@ public class ValueConverterRegistryTest {
 
     @Test(expected = ConstrettoException.class)
     public void testConvertUnsopportedClassConversion() {
-        ValueConverterRegistry.convertMap(getClass(), null, null);
+		final Map<String, CValue> map = new HashMap<String, CValue>();
+		map.put("hei", new CPrimitive("hallo"));
+		ValueConverterRegistry.convert(getClass(), getClass(), new CObject(map));
     }
 }


### PR DESCRIPTION
Added feature to find the "leaf" class for nested parameterization. This
way List<Map<String,String>> parameters work. Still complying to "simple
is better", and more complex object needs custom converters
