### PR TITLE
use webapp class loader

### DIFF
--- a/constretto-core/src/main/java/org/constretto/model/ClassPathResource.java
+++ b/constretto-core/src/main/java/org/constretto/model/ClassPathResource.java
@@ -22,7 +22,7 @@ public class ClassPathResource extends Resource {
 
     @Override
     public InputStream getInputStream() {
-        ClassLoader classLoader = this.getClass().getClassLoader();
+        ClassLoader classLoader = getClassLoader();
         String location;
         if (path.startsWith(CLASSPATH_PREFIX)) {
             location = path.substring(CLASSPATH_PREFIX.length(), path.length());
@@ -45,4 +45,14 @@ public class ClassPathResource extends Resource {
         }
         return result;
     }
+
+    private static ClassLoader getClassLoader() {
+        try {
+            return Thread.currentThread().getContextClassLoader();
+        }
+        catch (Throwable ex) {
+            return ClassPathResource.class.getClassLoader();
+        }
+    }
+
 }


### PR DESCRIPTION
Sometimes this library is loaded from the common class loader while resources are still in the webapp class loader. Using the thread's classloader ensures that the webapp classloader is used, which typically falls back to the common classloader when the resource is not found in the webapp classloader.

This is also how spring does it.
