### PR TITLE
Added support for a simple mapping api method. Given that a user has def...

### DIFF
--- a/constretto-api/src/main/java/org/constretto/ConstrettoConfiguration.java
+++ b/constretto-api/src/main/java/org/constretto/ConstrettoConfiguration.java
@@ -237,13 +237,10 @@ public interface ConstrettoConfiguration extends Iterable<Property> {
      * Will shuffle the configuration values to an instance of map.
      * This method requires you to have configured the required tags to resolve all properties in the configuration.
      *
-     * @param map the object to populate with key value pairs
-     * @param <T> th eobject type
      * @return a populated instance extending the {@link java.util.Map} interface
      * @throws ConstrettoException If some values are not qualifiable by the configured tags
      */
-    <T extends Map> T map(T map);
-
+    Map<String, String> asMap();
 
     /**
      * Appends (lower precedence) a new configuration tag at runtime.

--- a/constretto-core/src/main/java/org/constretto/internal/DefaultConstrettoConfiguration.java
+++ b/constretto-core/src/main/java/org/constretto/internal/DefaultConstrettoConfiguration.java
@@ -156,12 +156,15 @@ public class DefaultConstrettoConfiguration implements ConstrettoConfiguration {
         return objectToConfigure;
     }
 
-    @Override
-    public <T extends Map> T map(T map) {
-        for (Property property : this) {
-            map.put(property.getKey(), property.getValue());
+    public Map<String, String> asMap() {
+        Map<String, String> properties = new HashMap<String, String>();
+        for (Map.Entry<String, List<ConfigurationValue>> entry : configuration.entrySet()) {
+            ConfigurationValue value = findElementOrNull(entry.getKey());
+            if (value != null){
+                properties.put(entry.getKey(), value.value().toString());
+            }
         }
-        return map;
+        return properties;
     }
 
     public boolean hasValue(String expression) {
@@ -260,17 +263,6 @@ public class DefaultConstrettoConfiguration implements ConstrettoConfiguration {
 
     private <T> Constructor<T>[] findAnnotatedConstructorsOnClass(final Class<T> configurationClass) {
         return Constructors.findConstructorsWithConfigureAnnotation(configurationClass);
-    }
-
-    private Map<String, String> asMap() {
-        Map<String, String> properties = new HashMap<String, String>();
-        for (Map.Entry<String, List<ConfigurationValue>> entry : configuration.entrySet()) {
-            ConfigurationValue value = findElementOrNull(entry.getKey());
-            if (value != null){
-                properties.put(entry.getKey(), value.value().toString());
-            }
-        }
-        return properties;
     }
 
     protected ConfigurationValue findElementOrThrowException(String expression) {

--- a/constretto-core/src/test/java/org/constretto/ConstrettoConfigurationTest.java
+++ b/constretto-core/src/test/java/org/constretto/ConstrettoConfigurationTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,18 +32,18 @@ public class ConstrettoConfigurationTest {
                 .addResource(new ClassPathResource("test.properties"))
                 .done()
                 .getConfiguration()
-                .map(new Properties());
+                .asMap();
     }
 
     @Test
     public void youShouldBeAbleToGetConfigurationAsAMap() throws Exception {
-        Properties map = new ConstrettoBuilder(false)
+        Map<String, String> map = new ConstrettoBuilder(false)
                 .createPropertiesStore()
                 .addResource(new ClassPathResource("test.properties"))
                 .done()
                 .addCurrentTag("production")
                 .getConfiguration()
-                .map(new Properties());
+                .asMap();
         assertEquals(4, map.size());
     }
 


### PR DESCRIPTION
...ined the tags for which he/she wants to pull all properties as a map, let them supply an instance of a map, and populate it.

Can be user to populate java.util.Properties or any other map instance.
