### PR TITLE
Proof of concept for adding remote configuration stores to Constretto

### DIFF
--- a/constretto-core/src/main/java/org/constretto/ConstrettoBuilder.java
+++ b/constretto-core/src/main/java/org/constretto/ConstrettoBuilder.java
@@ -37,6 +37,7 @@ public class ConstrettoBuilder {
     private final List<String> tags;
     private final boolean enableSystemProps;
     private final Parser parser = new GsonParser();
+    private final Map<String, RemoteConfigurationStore> remoteConfigurationStore;
 
     public ConstrettoBuilder() {
         this(new DefaultConfigurationContextResolver(), true);
@@ -48,6 +49,7 @@ public class ConstrettoBuilder {
 
     public ConstrettoBuilder(ConfigurationContextResolver configurationContextResolver, boolean enableSystemProps) {
         this.configurationStores = new ArrayList<ConfigurationStore>();
+        this.remoteConfigurationStore = new HashMap<String, RemoteConfigurationStore>();
         this.tags = new ArrayList<String>();
         this.enableSystemProps = enableSystemProps;
         for (String tag : configurationContextResolver.getTags()) {
@@ -58,9 +60,10 @@ public class ConstrettoBuilder {
         }
     }
 
-    private ConstrettoBuilder(List<ConfigurationStore> configurationStores, List<String> tags, boolean enableSystemProps) {
+    private ConstrettoBuilder(List<ConfigurationStore> configurationStores, Map<String, RemoteConfigurationStore> remoteConfigurationStores, List<String> tags, boolean enableSystemProps) {
         this.enableSystemProps = enableSystemProps;
         this.configurationStores = configurationStores;
+        this.remoteConfigurationStore = remoteConfigurationStores;
         this.tags = tags;
     }
 
@@ -88,7 +91,7 @@ public class ConstrettoBuilder {
                 }
             }
         }
-        return new DefaultConstrettoConfiguration(configuration, tags);
+        return new DefaultConstrettoConfiguration(configuration, remoteConfigurationStore, tags);
     }
 
     private void addOverrideStores() {
@@ -117,12 +120,17 @@ public class ConstrettoBuilder {
 
     public ConstrettoBuilder addCurrentTag(String tag) {
         tags.add(tag);
-        return new ConstrettoBuilder(configurationStores, tags, enableSystemProps);
+        return new ConstrettoBuilder(configurationStores, remoteConfigurationStore, tags, enableSystemProps);
     }
 
     public ConstrettoBuilder addConfigurationStore(ConfigurationStore configurationStore) {
         configurationStores.add(configurationStore);
-        return new ConstrettoBuilder(configurationStores, tags, enableSystemProps);
+        return new ConstrettoBuilder(configurationStores, remoteConfigurationStore, tags, enableSystemProps);
+    }
+
+    public ConstrettoBuilder addRemoteConfigurationStore(String schema, RemoteConfigurationStore remote) {
+        remoteConfigurationStore.put(schema, remote);
+        return new ConstrettoBuilder(configurationStores, remoteConfigurationStore, tags, enableSystemProps);
     }
 
     public PropertiesStoreBuilder createPropertiesStore() {
@@ -143,7 +151,7 @@ public class ConstrettoBuilder {
 
     public ConstrettoBuilder createSystemPropertiesStore() {
         configurationStores.add(new SystemPropertiesStore());
-        return new ConstrettoBuilder(configurationStores, tags, enableSystemProps);
+        return new ConstrettoBuilder(configurationStores, remoteConfigurationStore, tags, enableSystemProps);
     }
 
     public ObjectConfigurationStoreBuilder createObjectConfigurationStore() {
@@ -182,7 +190,7 @@ public class ConstrettoBuilder {
         @Override
         final public ConstrettoBuilder done() {
             configurationStores.add(createStore());
-            return new ConstrettoBuilder(configurationStores, tags, enableSystemProps);
+            return new ConstrettoBuilder(configurationStores, remoteConfigurationStore, tags, enableSystemProps);
         }
     }
 

--- a/constretto-core/src/main/java/org/constretto/RemoteConfigurationStore.java
+++ b/constretto-core/src/main/java/org/constretto/RemoteConfigurationStore.java
@@ -1,0 +1,11 @@
+package org.constretto;
+
+import org.constretto.model.RemoteProperty;
+
+import java.util.List;
+
+public interface RemoteConfigurationStore {
+    
+    RemoteProperty getValue(String key, List<String> tag);
+
+}

--- a/constretto-core/src/main/java/org/constretto/model/RemoteProperty.java
+++ b/constretto-core/src/main/java/org/constretto/model/RemoteProperty.java
@@ -1,0 +1,30 @@
+package org.constretto.model;
+
+public class RemoteProperty {
+
+    private final String prop;
+
+    private RemoteProperty(String property) {
+        this.prop = property;
+    }
+
+    public String getProperty() {
+        if (!exists()) {
+            throw new NullPointerException("Property is not found");
+        }
+        return prop;
+    }
+
+    public boolean exists() {
+        return prop != null;
+    }
+    
+    public static RemoteProperty property(String property) {
+        return new RemoteProperty(property);
+    }
+    
+    public static RemoteProperty propertyNotFound() {
+        return new RemoteProperty(null);
+    }
+
+}

--- a/constretto-core/src/main/java/org/constretto/model/StringResource.java
+++ b/constretto-core/src/main/java/org/constretto/model/StringResource.java
@@ -1,0 +1,25 @@
+package org.constretto.model;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+public class StringResource extends Resource {
+
+    private String content;
+
+    public StringResource(String content) {
+        super("");
+        this.content = content;
+    }
+
+    @Override
+    public boolean exists() {
+        return true;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return new ByteArrayInputStream(content.getBytes(Charset.forName("UTF-8")));
+    }
+}

--- a/constretto-core/src/test/java/org/constretto/internal/provider/RemoteConfigurationTest.java
+++ b/constretto-core/src/test/java/org/constretto/internal/provider/RemoteConfigurationTest.java
@@ -1,0 +1,48 @@
+package org.constretto.internal.provider;
+
+import org.constretto.ConstrettoBuilder;
+import org.constretto.ConstrettoConfiguration;
+import org.constretto.RemoteConfigurationStore;
+import org.constretto.model.ClassPathResource;
+import org.constretto.model.RemoteProperty;
+import org.constretto.model.StringResource;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class RemoteConfigurationTest {
+    
+    @Test
+    public void simpleRemoteLookup() {
+        ConstrettoConfiguration configuration = new ConstrettoBuilder()
+                .addRemoteConfigurationStore("someschema", new DummyRemote())
+                .getConfiguration();
+
+        assertEquals("key1-value", configuration.evaluateToString("someschema:key1"));
+    }
+    
+    @Test
+    public void interpolateWithRemoteLookup() {
+        ConstrettoConfiguration configuration = new ConstrettoBuilder()
+                .createPropertiesStore()
+                    .addResource(new StringResource("prop.key:http://#{someschema:key1}"))
+                    .done()
+                .addRemoteConfigurationStore("someschema", new DummyRemote())
+                .getConfiguration();
+
+        assertEquals("http://key1-value", configuration.evaluateToString("prop.key"));
+    }
+
+    public static class DummyRemote implements RemoteConfigurationStore {
+
+        @Override
+        public RemoteProperty getValue(String key, List<String> tag) {
+            if (key.equals("key1")) {
+                return RemoteProperty.property("key1-value");
+            }
+            return RemoteProperty.propertyNotFound();
+        }
+    }
+}

--- a/constretto-core/src/test/java/org/constretto/model/RemotePropertyTest.java
+++ b/constretto-core/src/test/java/org/constretto/model/RemotePropertyTest.java
@@ -1,0 +1,16 @@
+package org.constretto.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RemotePropertyTest {
+    
+    @Test(expected = NullPointerException.class)
+    public void throwNullPointerWhenPropertyNotFound() {
+        RemoteProperty property = RemoteProperty.propertyNotFound();
+        
+        assertEquals(false, property.exists());
+        property.getProperty();
+    }
+}


### PR DESCRIPTION
A problem with the current ConfigurationStores is that it parses the whole configuration at once. When doing service discovery it would be ideal to only perform a query when a key is needed.

This suggested change add a concept of schemas for remote stores, to segregate them from regular keys. This makes it easier to only perform requests to the service discovery backend when necessary. This could of course bind the application more to the specific service discovery technlogy, but by using interpolation it is possible to use regular keys as still query the service discovery. By using interpolation it is also easier to prevent calls to a service discovery mechanism where it is not available, eg. when developing locally.

Examples:

```
config.evaluateToString("consul:service.backend.first.ip");
```

Will query Consul for an ip via a not yet implemented consul-store

```
backend.url=http://#{consul:service.backend.first.ip}/
@dev.backend.url=http://localhost:3000/
```

Will use service discovery as default, but will use a static address on local development

This is a proof of concept, so it is missing documentation.
