### PR TITLE
only do inject configuration in beans of scope singleton

### DIFF
--- a/constretto-spring/src/test/java/org/constretto/spring/configuration/EnvironmentAnnotatedFieldTest.java
+++ b/constretto-spring/src/test/java/org/constretto/spring/configuration/EnvironmentAnnotatedFieldTest.java
@@ -29,12 +29,18 @@ public class EnvironmentAnnotatedFieldTest {
 
     @Test
     public void givenClassWithEnvironmentAnnotatedPropertyThenInjectEnvironment() throws Exception {
-        TestClazz testClazz = new TestClazz();
         ConfigurationAnnotationConfigurer annotationConfigurer = new ConfigurationAnnotationConfigurer(
                 new DefaultConstrettoConfiguration(null), new AlwaysDevelopmentEnvironmentResolver());
-        annotationConfigurer.setBeanFactory(new TestBeanFactory());
+
+        TestClazz testClazz = new TestClazz();
+        annotationConfigurer.setBeanFactory(new TestBeanFactory(true));
         annotationConfigurer.postProcessAfterInstantiation(testClazz, "testBean");
         Assert.assertTrue(testClazz.getEnvironments().contains("development"));
+
+        TestClazz notSingletonTestClazz = new TestClazz();
+        annotationConfigurer.setBeanFactory(new TestBeanFactory(false));
+        annotationConfigurer.postProcessAfterInstantiation(notSingletonTestClazz, "testBean");
+        Assert.assertNull(notSingletonTestClazz.getEnvironments());
     }
 
     private class TestClazz {
@@ -48,6 +54,12 @@ public class EnvironmentAnnotatedFieldTest {
     }
 
     private class TestBeanFactory implements BeanFactory {
+
+        private boolean singleton;
+
+        TestBeanFactory(boolean singleton) {
+            this.singleton = singleton;
+        }
 
         @Override
         public Object getBean(final String name) throws BeansException {
@@ -76,7 +88,7 @@ public class EnvironmentAnnotatedFieldTest {
 
         @Override
         public boolean isSingleton(final String name) throws NoSuchBeanDefinitionException {
-            return true;
+            return singleton;
         }
 
         @Override

--- a/constretto-spring/src/test/java/org/constretto/spring/configuration/EnvironmentAnnotatedFieldTest.java
+++ b/constretto-spring/src/test/java/org/constretto/spring/configuration/EnvironmentAnnotatedFieldTest.java
@@ -16,6 +16,9 @@ import org.constretto.spring.annotation.Environment;
 import org.constretto.spring.assembly.helper.AlwaysDevelopmentEnvironmentResolver;
 import org.junit.Assert;
 import org.junit.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import java.util.List;
 
@@ -29,6 +32,7 @@ public class EnvironmentAnnotatedFieldTest {
         TestClazz testClazz = new TestClazz();
         ConfigurationAnnotationConfigurer annotationConfigurer = new ConfigurationAnnotationConfigurer(
                 new DefaultConstrettoConfiguration(null), new AlwaysDevelopmentEnvironmentResolver());
+        annotationConfigurer.setBeanFactory(new TestBeanFactory());
         annotationConfigurer.postProcessAfterInstantiation(testClazz, "testBean");
         Assert.assertTrue(testClazz.getEnvironments().contains("development"));
     }
@@ -40,6 +44,59 @@ public class EnvironmentAnnotatedFieldTest {
 
         public List<String> getEnvironments() {
             return environments;
+        }
+    }
+
+    private class TestBeanFactory implements BeanFactory {
+
+        @Override
+        public Object getBean(final String name) throws BeansException {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public <T> T getBean(final String name, final Class<T> requiredType) throws BeansException {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public <T> T getBean(final Class<T> requiredType) throws BeansException {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public Object getBean(final String name, final Object... args) throws BeansException {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public boolean containsBean(final String name) {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public boolean isSingleton(final String name) throws NoSuchBeanDefinitionException {
+            return true;
+        }
+
+        @Override
+        public boolean isPrototype(final String name) throws NoSuchBeanDefinitionException {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public boolean isTypeMatch(final String name, final Class<?> targetType) throws NoSuchBeanDefinitionException {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public Class<?> getType(final String name) throws NoSuchBeanDefinitionException {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public String[] getAliases(final String name) {
+            throw new UnsupportedOperationException("Not implemented");
         }
     }
 }

--- a/constretto-spring/src/test/java/org/constretto/spring/javaconfig/BasicConstrettoConfigurationTest.java
+++ b/constretto-spring/src/test/java/org/constretto/spring/javaconfig/BasicConstrettoConfigurationTest.java
@@ -5,7 +5,9 @@ import org.constretto.annotation.Configuration;
 import org.constretto.model.Resource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -19,21 +21,16 @@ import static org.junit.Assert.assertEquals;
 public class BasicConstrettoConfigurationTest {
 
     public static final String DEFAULT_VALUE = "Default";
-    @Configuration(required = true)
-    private String key1;
 
-    @Value("${key1}")
-    private String key1AsValue;
-
-    @Value("${nothere:" + DEFAULT_VALUE + "}")
-    private String defaultValue;
+    @Autowired
+    private TestBean testBean;
 
     @Test
     public void testKeyConfigured() throws Exception {
         final String expectedValue = "value1";
-        assertEquals(expectedValue, key1);
-        assertEquals(expectedValue, key1AsValue);
-        assertEquals(DEFAULT_VALUE, defaultValue);
+        assertEquals(expectedValue, testBean.key1);
+        assertEquals(expectedValue, testBean.key1AsValue);
+        assertEquals(DEFAULT_VALUE, testBean.defaultValue);
     }
 
     @org.springframework.context.annotation.Configuration
@@ -46,7 +43,23 @@ public class BasicConstrettoConfigurationTest {
                     .done()
                     .getConfiguration();
         }
+
+        @Bean
+        public TestBean testBean() {
+            return new TestBean();
+        }
+
     }
 
+    private static class TestBean {
+        @Configuration(required = true)
+        private String key1;
+
+        @Value("${key1}")
+        private String key1AsValue;
+
+        @Value("${nothere:" + DEFAULT_VALUE + "}")
+        private String defaultValue;
+    }
 
 }

--- a/constretto-spring/src/test/java/org/constretto/spring/javaconfig/BasicConstrettoConfigurationTest.java
+++ b/constretto-spring/src/test/java/org/constretto/spring/javaconfig/BasicConstrettoConfigurationTest.java
@@ -6,12 +6,16 @@ import org.constretto.model.Resource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author zapodot at gmail dot com
@@ -25,12 +29,19 @@ public class BasicConstrettoConfigurationTest {
     @Autowired
     private TestBean testBean;
 
+    @Autowired
+    @Qualifier("requestScopedBean")
+    private TestBean requestScopedTestBean;
+
     @Test
     public void testKeyConfigured() throws Exception {
         final String expectedValue = "value1";
         assertEquals(expectedValue, testBean.key1);
         assertEquals(expectedValue, testBean.key1AsValue);
         assertEquals(DEFAULT_VALUE, testBean.defaultValue);
+        assertNull(requestScopedTestBean.key1);
+        assertNull(requestScopedTestBean.key1AsValue);
+        assertNull(requestScopedTestBean.defaultValue);
     }
 
     @org.springframework.context.annotation.Configuration
@@ -49,9 +60,15 @@ public class BasicConstrettoConfigurationTest {
             return new TestBean();
         }
 
+        @Bean(name = "requestScopedBean")
+        @Scope(value="request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+        public TestBean requestScopedBean() {
+            return new TestBean();
+        }
+
     }
 
-    private static class TestBean {
+    public static class TestBean {
         @Configuration(required = true)
         private String key1;
 

--- a/constretto-test/src/test/java/org/constretto/test/ConstrettoRuleEnvironmentTest.java
+++ b/constretto-test/src/test/java/org/constretto/test/ConstrettoRuleEnvironmentTest.java
@@ -1,5 +1,7 @@
 package org.constretto.test;
 
+import java.util.List;
+
 import org.constretto.ConstrettoBuilder;
 import org.constretto.ConstrettoConfiguration;
 import org.constretto.spring.ConfigurationAnnotationConfigurer;
@@ -10,13 +12,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.util.List;
-
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * This source code is the property of NextGenTel AS
@@ -32,6 +36,10 @@ public class ConstrettoRuleEnvironmentTest {
 
     @Autowired
     private TestBean testBean;
+
+    @Autowired
+    @Qualifier("requestScopedBean")
+    private TestBean requestScopedBean;
 
     @Configuration
     public static class TestConfiguration {
@@ -56,6 +64,12 @@ public class ConstrettoRuleEnvironmentTest {
         TestBean testBean() {
             return new TestBean();
         }
+
+        @Bean(name = "requestScopedBean")
+        @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+        TestBean requestScopedBean() {
+            return new TestBean();
+        }
     }
 
 
@@ -65,9 +79,10 @@ public class ConstrettoRuleEnvironmentTest {
 
         assertArrayEquals(new String[]{ENVIRONMENT_VALUE}, testBean.injectedEnvironment.toArray(new String[1]));
 
+        assertNull(requestScopedBean.injectedEnvironment);
     }
 
-    static final class TestBean {
+    static class TestBean {
 
         @Environment
         private List<String> injectedEnvironment;

--- a/constretto-test/src/test/java/org/constretto/test/ConstrettoSpringJUnit4ClassRunnerTest.java
+++ b/constretto-test/src/test/java/org/constretto/test/ConstrettoSpringJUnit4ClassRunnerTest.java
@@ -17,6 +17,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.ArrayList;
@@ -32,19 +33,25 @@ import java.util.List;
 @ContextConfiguration
 public class ConstrettoSpringJUnit4ClassRunnerTest {
 
-    @Tags
-    List<String> currentEnvironment;
-
     @Autowired
-    Color color;
+    TestBean testBean;
 
     @Test
     public void givenEnvironmentAnnotationOnTestClassWhenRunningTestThenConstrettoKnowsEnvironment() {
         List<String> expected = new ArrayList<String>() {{
             add("springjunit");
         }};
-        Assert.assertArrayEquals(expected.toArray(new String[0]), currentEnvironment.toArray(new String[0]));
-        Assert.assertEquals("green", color.name());
+        Assert.assertArrayEquals(expected.toArray(new String[0]), testBean.currentEnvironment.toArray(new String[0]));
+        Assert.assertEquals("green", testBean.color.name());
+    }
+
+    static class TestBean {
+
+        @Autowired
+        Color color;
+
+        @Tags
+        List<String> currentEnvironment;
     }
 
 }

--- a/constretto-test/src/test/java/org/constretto/test/ConstrettoSpringJUnit4ClassRunnerTest.java
+++ b/constretto-test/src/test/java/org/constretto/test/ConstrettoSpringJUnit4ClassRunnerTest.java
@@ -10,6 +10,9 @@
  */
 package org.constretto.test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.constretto.annotation.Tags;
 import org.constretto.spring.annotation.Environment;
 import org.constretto.test.helper.Color;
@@ -17,11 +20,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
@@ -33,8 +33,11 @@ import java.util.List;
 @ContextConfiguration
 public class ConstrettoSpringJUnit4ClassRunnerTest {
 
-    @Autowired
+    @Autowired @Qualifier("testBean")
     TestBean testBean;
+
+    @Autowired @Qualifier("prototypeScopedTestBean")
+    TestBean prototypeScopedTestBean;
 
     @Test
     public void givenEnvironmentAnnotationOnTestClassWhenRunningTestThenConstrettoKnowsEnvironment() {
@@ -43,6 +46,8 @@ public class ConstrettoSpringJUnit4ClassRunnerTest {
         }};
         Assert.assertArrayEquals(expected.toArray(new String[0]), testBean.currentEnvironment.toArray(new String[0]));
         Assert.assertEquals("green", testBean.color.name());
+        Assert.assertNull(prototypeScopedTestBean.currentEnvironment);
+        Assert.assertEquals("green", prototypeScopedTestBean.color.name());
     }
 
     static class TestBean {

--- a/constretto-test/src/test/resources/org/constretto/test/ConstrettoSpringJUnit4ClassRunnerTest-context.xml
+++ b/constretto-test/src/test/resources/org/constretto/test/ConstrettoSpringJUnit4ClassRunnerTest-context.xml
@@ -18,4 +18,6 @@
   <constretto:configuration/>
   <context:component-scan base-package="org.constretto.test.helper"/>
 
+  <bean class="org.constretto.test.ConstrettoSpringJUnit4ClassRunnerTest.TestBean"/>
+
 </beans>

--- a/constretto-test/src/test/resources/org/constretto/test/ConstrettoSpringJUnit4ClassRunnerTest-context.xml
+++ b/constretto-test/src/test/resources/org/constretto/test/ConstrettoSpringJUnit4ClassRunnerTest-context.xml
@@ -18,6 +18,8 @@
   <constretto:configuration/>
   <context:component-scan base-package="org.constretto.test.helper"/>
 
-  <bean class="org.constretto.test.ConstrettoSpringJUnit4ClassRunnerTest.TestBean"/>
+  <bean class="org.constretto.test.ConstrettoSpringJUnit4ClassRunnerTest.TestBean" name="testBean"/>
+
+  <bean class="org.constretto.test.ConstrettoSpringJUnit4ClassRunnerTest.TestBean" name="prototypeScopedTestBean" scope="prototype"/>
 
 </beans>


### PR DESCRIPTION
 so as to avoid resource starvation on request/session/prototype scoped beans under heavy load.

ConfigurationAnnotationConfigurer from constretto-spring tries to inject constretto configuration in *all* beans after they are instantiated by Spring. This includes request-scoped bean (also session-scoped beans and prototype beans). In addition, injecting the configuration includes the process of keeping track of all configured objects in a CopyOnWriteArraySet which internally uses ReentrantLock. In a high traffic application using request-scoped beans this quickly leads to constretto interlocking itself and leaking threads.

No actual use of constretto in those beans is required for the issue to actually happen, just having constretto-spring on the classpath and loaded by Spring (f.ex.: ```<constretto:configuration>```), plus having some spring beans other than singletons.

This patch takes the path of only injecting configuration in singleton beans. I used Apache Benchmark and JProfiler to double check that the thread leaking disappeared.