### PR TITLE
Proposed feature: Property key from String field value

### DIFF
--- a/constretto-core/src/main/java/org/constretto/internal/DefaultConstrettoConfiguration.java
+++ b/constretto-core/src/main/java/org/constretto/internal/DefaultConstrettoConfiguration.java
@@ -475,7 +475,7 @@ public class DefaultConstrettoConfiguration implements ConstrettoConfiguration {
                 try {
                     if (field.isAnnotationPresent(Configuration.class)) {
                         Configuration configurationAnnotation = field.getAnnotation(Configuration.class);
-                        String expression = "".equals(configurationAnnotation.value()) ? field.getName() : configurationAnnotation.value();
+                        String expression = getExpression(objectToConfigure, field, configurationAnnotation);
                         field.setAccessible(true);
                         Class<?> fieldType = field.getType();
                         if (hasValue(expression)) {
@@ -512,6 +512,29 @@ public class DefaultConstrettoConfiguration implements ConstrettoConfiguration {
                 }
             }
         } while ((objectToConfigureClass = objectToConfigureClass.getSuperclass()) != null);
+    }
+
+    /**
+     * If @Configuration() has value, this is used;
+     * if field is non-empty String, its value is used;
+     * otherwise, field name is used.
+     *
+     * @return Property key
+     */
+    private static <T> String getExpression(T objectToConfigure, Field field, Configuration configurationAnnotation) {
+        String expression = configurationAnnotation.value();
+        if ("".equals(configurationAnnotation.value())) {
+            expression = field.getName();
+            if (String.class.equals(field.getType())) {
+                try {
+                    String value = (String) field.get(objectToConfigure);
+                    if (value != null && value.length() > 0) {
+                        expression = value;
+                    }
+                } catch (IllegalAccessException  ile) { }
+            }
+        }
+        return expression;
     }
 
     private boolean hasAnnotationDefaults(Configuration configurationAnnotation) {

--- a/constretto-core/src/test/java/org/constretto/ConstrettoConfigurationTest.java
+++ b/constretto-core/src/test/java/org/constretto/ConstrettoConfigurationTest.java
@@ -25,7 +25,7 @@ public class ConstrettoConfigurationTest {
         assertNotNull(configuration);
     }
 
-    @Test(expected = ConstrettoExpressionException.class) //TODO perhaps a more specific expeption
+    @Test(expected = ConstrettoExpressionException.class) //TODO perhaps a more specific exception
     public void shouldThrowExceptionIfTryingToMapWithoutNeededAllTagsProvided() throws Exception {
         new ConstrettoBuilder(false)
                 .createPropertiesStore()

--- a/constretto-core/src/test/java/org/constretto/internal/provider/ConfigurationAnnotationsTest.java
+++ b/constretto-core/src/test/java/org/constretto/internal/provider/ConfigurationAnnotationsTest.java
@@ -45,6 +45,7 @@ public class ConfigurationAnnotationsTest {
         setProperty("password", "password");
         setProperty("vendor", "derby");
         setProperty("version", "10");
+        setProperty("derby.system.home", "C:\\home\\Derby\\");
         setProperty("array", "[\"one\",\"two\",\"three\"]");
         setProperty("map", "{\"1\":\"10\",\"2\":\"20\"}");
         configuration = new ConstrettoBuilder().createSystemPropertiesStore().getConfiguration();
@@ -69,6 +70,7 @@ public class ConfigurationAnnotationsTest {
         assertEquals("username", customerDataSource.getUsername());
         assertEquals("jdbc://url", customerDataSource.getUrl());
         assertEquals("password", customerDataSource.getPassword());
+        assertEquals("C:\\home\\Derby\\", customerDataSource.homeDir);
         assertEquals(new Integer(10), customerDataSource.getVersion());
     }
 

--- a/constretto-core/src/test/java/org/constretto/internal/provider/helper/DataSourceConfiguration.java
+++ b/constretto-core/src/test/java/org/constretto/internal/provider/helper/DataSourceConfiguration.java
@@ -33,6 +33,8 @@ public class DataSourceConfiguration {
     @Configuration("username")
     private String myUsername;
 
+    @Configuration
+    public String homeDir = "derby.system.home";
 
     @Configure
     public void configureMe(@Configuration String url, @Configuration("password") String secret) {


### PR DESCRIPTION
Currently, field name is used as key when @Configuration annotation has no value.

A benefit of this is that the key is clearly visible everywhere the field is accessed.

It cannot work, however, if the key consists of periods, like my.example.property=X

Which is why I propose support for using field value as key expression.

In most (?) IDEs, the key expression can then be viewed with Ctrl+mouseover or similar.

This also means less duplication of key expressions.

There are some disadvantages, like only working for String, which is why I won't be too sad if this feature request is not accepted :-)