### PR TITLE
Expose path in Resource.

### DIFF
--- a/constretto-core/src/main/java/org/constretto/model/Resource.java
+++ b/constretto-core/src/main/java/org/constretto/model/Resource.java
@@ -52,4 +52,8 @@ public abstract class Resource {
         sb.append('}');
         return sb.toString();
     }
+
+    public String getPath(){
+        return this.path;
+    }
 }

--- a/constretto-core/src/test/java/org/constretto/model/ClassPathResourceTest.java
+++ b/constretto-core/src/test/java/org/constretto/model/ClassPathResourceTest.java
@@ -33,6 +33,11 @@ public class ClassPathResourceTest {
     public void testToString() throws Exception {
         final ClassPathResource classPathResource = new ClassPathResource(NON_EXISITING_CLASSPATH_RESOURCE);
         assertEquals("ClassPathResource{path='" + NON_EXISITING_CLASSPATH_RESOURCE + "'}", classPathResource.toString());
+    }
 
+    @Test
+    public void testGetPath() throws Exception {
+        final ClassPathResource classPathResource = new ClassPathResource(NON_EXISITING_CLASSPATH_RESOURCE);
+        assertEquals(NON_EXISITING_CLASSPATH_RESOURCE, classPathResource.getPath());
     }
 }

--- a/constretto-core/src/test/java/org/constretto/model/FileResourceTest.java
+++ b/constretto-core/src/test/java/org/constretto/model/FileResourceTest.java
@@ -59,6 +59,13 @@ public class FileResourceTest {
         assertEquals("FileResource{path='file:src/test/resources/cache1.ini'}", fileResource.toString());
     }
 
+    @Test
+    public void testGetPath() throws Exception {
+        String testPath = "file:src/test/resources/cache1.ini";
+        final FileResource fileResource = new FileResource(testPath);
+        assertEquals(fileResource.getPath(), testPath);
+    }
+
     /**
      * If file name starts with file: chances are it is a file url.
      * Constretto should decode this url since it uses new File(String) which does not support

--- a/constretto-core/src/test/java/org/constretto/model/UrlResourceTest.java
+++ b/constretto-core/src/test/java/org/constretto/model/UrlResourceTest.java
@@ -40,7 +40,13 @@ public class UrlResourceTest {
     public void testToString() throws Exception {
         final UrlResource urlResource = new UrlResource("http://vg.no");
         assertEquals("UrlResource{path='http://vg.no'}", urlResource.toString());
+    }
 
+
+    @Test
+    public void testGetPath() throws Exception {
+        final UrlResource urlResource = new UrlResource("http://vg.no");
+        assertEquals(urlResource.getPath(), "http://vg.no");
     }
 
 }


### PR DESCRIPTION
It is already exposed as part of the toString-method, but there shouldn't be a reason
to use regex to get it.