### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ somedb.username=default username
 @systest.somedb.username=username in system test
 ```
 
-###Ini Files
+### Ini Files
 
 Constretto also supports Ini files and here, sections are used as tags
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
