### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ after_success:
 - echo "<settings><servers><server><id>sonatype-nexus-snapshots</id><username>\${env.REPO_USER}</username><password>\${env.REPO_PASSWORD}</password></server></servers></settings>" > ~/settings.xml
 - mvn deploy --settings ~/settings.xml
 
+
+git:
+  depth: 1


### PR DESCRIPTION
Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.