### PR TITLE
Null checks on CValue

### DIFF
--- a/constretto-api/src/main/java/org/constretto/model/CArray.java
+++ b/constretto-api/src/main/java/org/constretto/model/CArray.java
@@ -12,7 +12,7 @@ public class CArray extends CValue {
 
     public CArray(final List<CValue> data) {
 
-        if(data == null) {
+        if (data == null) {
             throw new NullPointerException("The \"data\" argument can not be null");
         }
         this.data = Arrays.asList(data.toArray(new CValue[]{}));
@@ -26,7 +26,9 @@ public class CArray extends CValue {
     public Set<String> referencedKeys() {
         Set<String> referencedKeys = new HashSet<String>();
         for (CValue value : data) {
-            referencedKeys.addAll(value.referencedKeys());
+            if (value != null) {
+                referencedKeys.addAll(value.referencedKeys());
+            }
         }
         return referencedKeys;
     }
@@ -34,7 +36,9 @@ public class CArray extends CValue {
     @Override
     public void replace(String key, String resolvedValue) {
         for (CValue value : data) {
-            value.replace(key, resolvedValue);
+            if (value != null) {
+                value.replace(key, resolvedValue);
+            }
         }
     }
 

--- a/constretto-api/src/main/java/org/constretto/model/CObject.java
+++ b/constretto-api/src/main/java/org/constretto/model/CObject.java
@@ -12,7 +12,7 @@ public class CObject extends CValue {
 
     public CObject(Map<String, CValue> data) {
 
-        if(data == null) {
+        if (data == null) {
             throw new NullPointerException("The \"data\" argument can not be null");
         }
         this.data = data;
@@ -26,7 +26,9 @@ public class CObject extends CValue {
     public Set<String> referencedKeys() {
         Set<String> referencedKeys = new HashSet<String>();
         for (CValue value : data.values()) {
-            referencedKeys.addAll(value.referencedKeys());
+            if (value != null) {
+                referencedKeys.addAll(value.referencedKeys());
+            }
         }
         return referencedKeys;
     }
@@ -34,7 +36,9 @@ public class CObject extends CValue {
     @Override
     public void replace(String key, String resolvedValue) {
         for (CValue value : data.values()) {
-            value.replace(key, resolvedValue);
+            if (value != null) {
+                value.replace(key, resolvedValue);
+            }
         }
     }
 
@@ -46,9 +50,9 @@ public class CObject extends CValue {
         for (Map.Entry<String, CValue> entry : data.entrySet()) {
             stringBuilder.append(entry.getKey());
             stringBuilder.append(':');
-            stringBuilder.append(entry.getValue().toString());
+            stringBuilder.append(entry.getValue() == null ? "null" : entry.getValue().toString());
             elementsAdded++;
-            if(elementsAdded < length) {
+            if (elementsAdded < length) {
                 stringBuilder.append(", ");
             }
         }

--- a/constretto-api/src/main/java/org/constretto/model/CPrimitive.java
+++ b/constretto-api/src/main/java/org/constretto/model/CPrimitive.java
@@ -37,7 +37,9 @@ public class CPrimitive extends CValue {
 
     @Override
     public void replace(String key, String resolvedValue) {
-        value = value.replaceAll("#\\{" + key + "\\}", Matcher.quoteReplacement(resolvedValue));
+        if (value != null) {
+            value = value.replaceAll("#\\{" + key + "\\}", Matcher.quoteReplacement(resolvedValue));
+        }
     }
 
     @Override


### PR DESCRIPTION
After a change in Travis we started getting NPE's when building.  Probably a weirdly formatted environment variable, but I wasn't able to pin it down.  Exception was:
```
Caused by: java.lang.NullPointerException: Cannot invoke "org.constretto.model.CValue.referencedKeys()" because "value" is null
	at org.constretto.model.CObject.referencedKeys(CObject.java:29)
	at org.constretto.model.CValue.containsVariables(CValue.java:13)
	at org.constretto.internal.DefaultConstrettoConfiguration.findElementOrNull(DefaultConstrettoConfiguration.java:295)
	at org.constretto.internal.DefaultConstrettoConfiguration.asMap(DefaultConstrettoConfiguration.java:162)
```